### PR TITLE
add table structure and attributes description to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,45 @@ Backend for the backend of the org app for Reach4Help
 When the server starts have a go with the GraphQL playground at:
 
 - `http://localhost:4000/`
+
+### Database Structure
+
+Organizations
+(has_many Users)
+(has_many Programs)
+(has_many Forms)
+- id
+- name
+
+Users 
+(belongs to Organization)
+(has_many Programs through ProgramAssignments)
+(Polymorphic child tables: Volunteers, Beneficiaries, Directors, Managers)
+- id
+- name
+- organization_id (foreign_key)
+
+
+Programs
+(has_many Users through ProgramAssignments)
+- id
+- name
+
+Requests
+(has_many Users through RequestAssignments)
+- id
+
+RequestAssignments
+- id
+- user_id (foreign_key)
+- request_id (foreign_key)
+
+ProgramAssignments
+- id 
+- user_id (foreign_key)
+- program_id (foreign_key)
+
+Forms 
+(belongs_to Organization)
+- id
+- organization_id (foreign_key)

--- a/README.md
+++ b/README.md
@@ -33,16 +33,21 @@ Users
 - id
 - name
 - organization_id (foreign_key)
+- request_assignment_id (foreign_key)
+- program_assignment_id (foreign_key)
 
 
 Programs
 (has_many Users through ProgramAssignments)
 - id
 - name
+- organization_id (foreign_key)
+- program_assignment_id (foreign_key)
 
 Requests
 (has_many Users through RequestAssignments)
 - id
+- request_assignment_id
 
 RequestAssignments
 - id

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Requests
 
 RequestAssignments
 - id
-- user_id (foreign_key)
+- volunteer_id (foreign_key to polymorphic Users table)
+- beneficiary_id (foreign_key to polymorphic Users table)
 - request_id (foreign_key)
 
 ProgramAssignments


### PR DESCRIPTION
Adds a list of tables with relationship descriptions and a beginning attributes list to the readme. Will be built up more later. The purpose is to give the frontend a structure to begin building mock requests. 